### PR TITLE
Revert "discord link"

### DIFF
--- a/src/components/Discord/Discord.css
+++ b/src/components/Discord/Discord.css
@@ -2,17 +2,27 @@
     position: relative;
     width: 100%;
     height: 100%;
-    /* Ensure it covers the full viewport height */
-    overflow: hidden;
 }
 
+
+.star-background {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-image: url('../../assets/images/discord/stars.svg');
+    background-size: cover;
+    background-repeat: repeat;
+    opacity: 0.9;
+    z-index: 2;
+}
 
 .bottom-overlay {
     position: absolute;
     bottom: 25%;
     left: 37%;
     width: 27%;
-    height: 21%;
+    height: 23%;
     cursor: pointer;
-    z-index: 3;
 }

--- a/src/components/Discord/Discord.jsx
+++ b/src/components/Discord/Discord.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import Bgimage from '../../assets/images/discord/JOIN2.png';
-import stars from '../../assets/images/discord/stars.svg'
 import './Discord.css';
 
 function Discord() {
@@ -23,21 +22,14 @@ function Discord() {
 
     return (
         <div className="section">
-            <div className="relative w-screen flex items-start justify-center" style={{
-                backgroundImage: `url(${stars})`,
-                backgroundPosition: `${50 + bgPosition.x}% ${50 + bgPosition.y}%`,
-                backgroundSize: 'cover',
-            }}>
-            <img src={Bgimage} alt="Join Discord" className="img-background" />
-            
+            <div className="star-background" style={{ transform: `translate(${bgPosition.x}px, ${bgPosition.y}px)` }}></div>
+            <img src={Bgimage} alt="" className='img-background' />
             <a
                 href="https://discord.gg/UHwPBzy7UF"
                 className="bottom-overlay"
                 target="_blank"
                 rel="noopener noreferrer"
-            >
-            </a>
-            </div>
+            ></a>
         </div>
     );
 }


### PR DESCRIPTION
Reverts IIITKalyaniFOSC/Hackathon-website-2024#21

Reverting for now only. This does not fix the opposite parallax for the discord section. Just stops the parallax for some reason.

https://github.com/IIITKalyaniFOSC/Hackathon-website-2024/assets/97747495/a59bf511-b672-4789-b29e-3305cddbae9a

